### PR TITLE
Fix colour handling

### DIFF
--- a/pyriodic/viz.py
+++ b/pyriodic/viz.py
@@ -51,7 +51,8 @@ class CircPlot:
         self.prepare_ax(ylim=ylim)
 
         if colours:
-            self.colours = [colours] if colours.type() == "str" else colours
+            # Allow either a single colour string or an iterable of colours
+            self.colours = [colours] if isinstance(colours, str) else colours
         else:
             # Automatically pick colors from matplotlib's default cycle
             prop_cycle = plt.rcParams["axes.prop_cycle"]


### PR DESCRIPTION
## Summary
- fix logic for handling `CircPlot` `colours` argument

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6853d1d36c388326a242a945878a6edb